### PR TITLE
Android build: use implementation instead of compile, add compileSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
+        compileSdkVersion safeExtGet('compileSdkVersion', 23)
         targetSdkVersion safeExtGet('targetSdkVersion', 23)
         versionCode 1
         versionName "1.0"
@@ -54,6 +55,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
Fix for https://github.com/Crypho/react-native-scrypt/issues/10 (closed but not actually solved). Included in this fork because the original repo does not seem to want to merge https://github.com/Crypho/react-native-scrypt/pull/48 